### PR TITLE
Add check for 5F vs 4F scheme, remove unavialble pdfs

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -343,7 +343,14 @@ if [ ! -d ${AFS_GEN_FOLDER}/${name}_gridpack ]; then
   #Run the code-generation step to create the process directory
   ########################
 
+  # Used to figure out if 4F or 5F scheme
+  sed -i '$ a display multiparticles' ${name}_proc_card.dat
   ./$MGBASEDIRORIG/bin/mg5_aMC ${name}_proc_card.dat
+ 
+  is5FlavorScheme=0
+  if tail -n 20 $LOGFILE | grep -q -e "^p *=.*b\~.*b" -e "^p *=.*b.*b\~"; then 
+    is5FlavorScheme=1
+  fi
 
   #*FIXME* workaround for broken set cluster_queue handling
   if [ "$queue" == "condor" ]; then
@@ -468,8 +475,8 @@ fi
 if [ "$isnlo" -gt "0" ]; then
   if grep -q -e "\$DEFAULT_PDF_SETS" -e "\$DEFAULT_PDF_MEMBERS" $CARDSDIR/${name}_run_card.dat; then
     echo "INFO: Using default PDF sets for 2017 production"
-          sed "s/\$DEFAULT_PDF_SETS/306000,322500,322700,322900,323100,323300,323500,323700,323900,292200,292600,305800,315000,13100,13163,13167,13000,13065,13069,13200,25200,25300,25000,42780,90200,91200,90400,91400,61100,61130,61200,61230,13400,82000/" $CARDSDIR/${name}_run_card.dat > ./Cards/run_card.dat
-    sed -i "s/\$DEFAULT_PDF_MEMBERS/True,  False, False, False, False, False, False, False, False, True,  False, True,  False, True, False,False,True, False,False,False,True, True, False,False,True, True, True, True, True, True, True, True, True, True/" ./Cards/run_card.dat 
+          sed "s/\$DEFAULT_PDF_SETS/306000,292200,292600,305800,315000,13100,13163,13167,13000,13065,13069,13200,25200,25300,25000,42780,90200,91200,90400,91400,61100,61130,61200,61230,13400,82000/" $CARDSDIR/${name}_run_card.dat > ./Cards/run_card.dat
+    sed -i "s/\$DEFAULT_PDF_MEMBERS/True,  True,  False, True,  False, True, False,False,True, False,False,False,True, True, False,False,True, True, True, True, True, True, True, True, True, True/" ./Cards/run_card.dat 
   else
     echo ""
     echo "WARNING: You've chosen not to use the PDF sets recommended for 2017 production!"


### PR DESCRIPTION
Check for 5F vs. 4F by checking to see if the b is part of the proton
definition. This isn't a perfect check but it seems the best combination
of straightforward and rigorous. Also remove the PDFs which are not yet
supported in CMSSW LHAPDF installation.